### PR TITLE
Polyfill should not add enumerable property

### DIFF
--- a/lib/polyfills.js
+++ b/lib/polyfills.js
@@ -5,5 +5,7 @@
 
 // internal-ip@2.x uses [].includes
 if (!Array.prototype.includes) {
-  Array.prototype.includes = require('array-includes');
+	Object.defineProperty(Array.prototype, 'includes', {
+		value: require('array-includes')
+	});
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixed a potential bug in a polyfill.

**Did you add or update the `examples/`?**

Not needed.

**Summary**

Adding ``includes`` as an enumerable property does not seem like the best idea, since it breaks code using for/in with an array, like the one used in webfont-generator (https://github.com/sunflowerdeath/webfonts-generator/blob/master/src/generateFonts.js#L125) and webfont-loader (https://github.com/jmhdez/webfonts-loader/blob/master/index.js#L170)

**Does this PR introduce a breaking change?**

No

**Other information**
